### PR TITLE
修复拼图功能时间转换问题

### DIFF
--- a/metradar/project/make_mosaic/make_mosaic_func.py
+++ b/metradar/project/make_mosaic/make_mosaic_func.py
@@ -420,7 +420,7 @@ class MAKE_RADAR_MOSAIC:
         print('periods = %d'%periods)
         dt = pd.date_range(st,freq='%dmin'%self.tstep,periods=periods)
         dt = pd.to_datetime(dt)
-        alltimes=[tt.strftime('%Y%m%d%H%M') for tt in dt]
+        alltimes=[tt.strftime('%Y%m%d%H%M') + '00' for tt in dt]
 
         rootpath = self.input_path_archive
         outpath = self.output_path_archive


### PR DESCRIPTION
原代码中拼图的归档模式的tsstep会导致step以秒为单位匹配基数据。修复后可正常按照分钟为单位进行基数据匹配